### PR TITLE
Add permission service and user show sad path

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -15,6 +15,7 @@
   color: white;
   background-color: rgba(41,128,185,.3);
 }
+
 .light {
   font-weight: 300;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,25 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user
+  before_action :authorize!
+
+  def authorize!
+    unless authorized?
+      flash[:info] = "Please signin first:)"
+      redirect_to root_path
+    end
+  end
 
   private
     def current_user
       @current_user ||= User.find(session[:user_id]) if session[:user_id]
+    end
+
+    def authorized?
+    current_permission.allow?
+    end
+
+    def current_permission
+      @current_permission ||= Permission.new(current_user, params[:controller], params[:action])
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,9 @@ class UsersController < ApplicationController
   def show
     @twitter_service = TwitterService.new(current_user)
     @user = params[:screen_name]
+    if !@twitter_service.user(@user)
+      redirect_to user_path(current_user.screen_name)
+      flash[:info] = "Hey, that person doesn't exist."
+    end
   end
 end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -1,0 +1,40 @@
+class Permission
+
+  def initialize(user, controller, action)
+    @_user = user
+    @_controller = controller
+    @_action = action
+  end
+
+  def allow?
+    if user
+      user_permissions
+    else
+      home_page_permission
+    end
+  end
+
+  private
+    def user
+      @_user
+    end
+
+    def controller
+      @_controller
+    end
+
+    def action
+      @_action
+    end
+
+    def user_permissions
+      return true if controller == 'sessions' && action.in?(%w(destroy))
+      return true if controller == 'users' && action.in?(%w(show))
+      return true if controller == 'static_pages' && action.in?(%w(home))
+    end
+
+    def home_page_permission
+      return true if controller == 'sessions' && action.in?(%w(create))
+      return true if controller == 'static_pages' && action.in?(%w(home))
+    end
+end

--- a/app/services/twitter_service.rb
+++ b/app/services/twitter_service.rb
@@ -15,7 +15,9 @@ class TwitterService
   end
 
   def user(user_screen_name)
-    client.user(user_screen_name)
+    if client.user?(user_screen_name)
+      client.user(user_screen_name)
+    end
   end
 
   private


### PR DESCRIPTION
Permissions now set for users and non-users. If a non-user attempts to navigate the app, they will be redirected back to the home page and prompted to signin.

If users attempt to navigate to a non-existent user show page, they will now be redirected to their show page with a flash message letting them know that the user they tried to visit does not exist.
