### PR TITLE
Implement 10 hour caching for users/show

### DIFF
--- a/app/services/twitter_service.rb
+++ b/app/services/twitter_service.rb
@@ -11,12 +11,16 @@ class TwitterService
   end
 
   def user_timeline(user_screen_name)
-    client.user_timeline(user_screen_name, {count: 25, include_rts: true})
+    Rails.cache.fetch("tweets/#{user_screen_name}", :expires_in => 10.hours) do
+      client.user_timeline(user_screen_name, {count: 25, include_rts: true})
+    end
   end
 
   def user(user_screen_name)
-    if client.user?(user_screen_name)
-      client.user(user_screen_name)
+    Rails.cache.fetch("#{user_screen_name}", :expires_in => 10.hours) do
+      if client.user?(user_screen_name)
+        client.user(user_screen_name)
+      end
     end
   end
 


### PR DESCRIPTION
Use low-level Rails cacheing (Rails.cache.fetch) to cache user profile info and past 25 tweets for ten hours.
