### PR TITLE
Update tweet time to display in relative time

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,7 +19,7 @@
       <div class="col-xs-12 float-right col">
         <% poro_tweet = Tweet.new(tweet) %>
         <div id="<%= index %>-tweet" class="tweet thumbnail">
-          <h5><%= poro_tweet.text.html_safe %><br><span class="tweet-date"><%= tweet.created_at.to_time.strftime("%B %-d, %Y |%l:%M%P") %></span></h5>
+          <h5><%= poro_tweet.text.html_safe %><br><span class="tweet-date"><%= "#{time_ago_in_words(tweet.created_at)} ago" %></span></h5>
           <% poro_tweet.media.each do |object| %>
             <%= object.html_safe %>
           <% end %>


### PR DESCRIPTION
This choice was made after weighing the various options for displaying time to the user in the correct timezone.  Options weighed: store timezone on user, hard code specific timezone, let heroku default the timezone, try IP-based geo coding, or use relative times.  From a UX standpoint, I concluded the best choice was relative time (as I expect Twitter concluded for the same reasons).
