### PR TITLE
Searching for private users redirects to current

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,9 +3,9 @@ class UsersController < ApplicationController
   def show
     @twitter_service = TwitterService.new(current_user)
     @user = params[:screen_name]
-    if !@twitter_service.user(@user)
+    if !@twitter_service.user(@user) || @twitter_service.user(@user).protected?
       redirect_to user_path(current_user.screen_name)
-      flash[:info] = "Hey, that person doesn't exist."
+      flash[:info] = "Hey, either that person doesn't exist, or they have a private account."
     end
   end
 

--- a/spec/features/user_views_other_users_spec.rb
+++ b/spec/features/user_views_other_users_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "user logs in and views other users" do
     end
   end
 
- scenario "user serces for user that does not exist" do
+ scenario "user searches for user that does not exist" do
     VCR.use_cassette("invalid_user_show") do
       stub_omniauth
       visit "/"
@@ -32,7 +32,7 @@ RSpec.feature "user logs in and views other users" do
       click_on "search for users"
 
       expect(current_path).to eq(user_path(ENV['TWITTER_USER_SCREEN_NAME']))
-      expect(page).to have_content("Hey, that person doesn't exist.")
+      expect(page).to have_content("Hey, either that person doesn't exist, or they have a private account.")
 
       expect(page).to have_css('div#1-tweet')
       expect(page).to have_css('div#5-tweet')
@@ -45,4 +45,27 @@ RSpec.feature "user logs in and views other users" do
      end
     end
   end
+
+  scenario "user searches for user with private account" do
+     VCR.use_cassette("private_user_show") do
+       stub_omniauth
+       visit "/"
+       click_on "sign in with twitter"
+       fill_in "screen_name", with: "turing"
+       click_on "search for users"
+
+       expect(current_path).to eq(user_path(ENV['TWITTER_USER_SCREEN_NAME']))
+       expect(page).to have_content("Hey, either that person doesn't exist, or they have a private account.")
+
+       expect(page).to have_css('div#1-tweet')
+       expect(page).to have_css('div#5-tweet')
+       expect(page).to have_css('div#10-tweet')
+       expect(page).to have_css('div#24-tweet')
+
+       within "div.user" do
+         expect(page).to have_content(ENV['TWITTER_USER_NAME'])
+         expect(page).to have_link(ENV['TWITTER_USER_SCREEN_NAME'])
+      end
+     end
+   end
 end


### PR DESCRIPTION
Patch to account for private twitter users.  When searching for a user that has a private account, you are now redirected to your profile.
